### PR TITLE
Vault access roles

### DIFF
--- a/contracts/PKKTRewardManager.sol
+++ b/contracts/PKKTRewardManager.sol
@@ -59,7 +59,7 @@ abstract contract PKKTRewardManager is IClaimable, Ownable {
     }
 
     //Update number of pkkt per block 
-    function setPKKTPerBlock(uint256 _pkktPerBlock) public onlyOwner {
+    function setPKKTPerBlock(uint256 _pkktPerBlock) public virtual onlyOwner {
         massUpdatePools();
         pkktPerBlock = _pkktPerBlock;
     }

--- a/contracts/PKKTVault.sol
+++ b/contracts/PKKTVault.sol
@@ -380,7 +380,8 @@ contract PKKTVault is PKKTRewardManager, AccessControl {
     }
 
     //Update number of pkkt per block 
-    function setPKKTPerBlock(uint256 _pkktPerBlock) public override onlyRole(TRADER_ROLE) {
+    function setPKKTPerBlock(uint256 _pkktPerBlock) public override {
+        require(hasRole(TRADER_ROLE, msg.sender) || owner() == msg.sender, "Only the owner or trader can set PKKT per block.");
         massUpdatePools();
         pkktPerBlock = _pkktPerBlock;
     }

--- a/contracts/PKKTVault.sol
+++ b/contracts/PKKTVault.sol
@@ -310,7 +310,7 @@ contract PKKTVault is PKKTRewardManager, AccessControl {
     /************************************************
      *  SETTLEMENT
      ***********************************************/
-    function initiateSettlement(uint256 _pkktPerBlock) external onlyRole(TRADER_ROLE) {
+    function initiateSettlement(uint256 _pkktPerBlock, address target) external onlyRole(TRADER_ROLE) {
         massUpdatePools();
         isSettelled = false;
         uint256 vaultCount = vaultInfo.length; 
@@ -353,7 +353,7 @@ contract PKKTVault is PKKTRewardManager, AccessControl {
            }
            else if (diff2 > 0) {
                Vault.VaultInfo storage vault = vaultInfo[vid];
-               IERC20(vault.underlying).safeTransfer(address(msg.sender), uint256(diff2)); 
+               IERC20(vault.underlying).safeTransfer(address(target), uint256(diff2)); 
            }
         }
         if (allDone) {

--- a/test/PKKTVault.ts
+++ b/test/PKKTVault.ts
@@ -384,6 +384,18 @@ describe("PKKT Vault", async function () {
           await pkktVault.connect(trader as Signer).initiateSettlement("100");
         });
 
+        it("should only allow the trader and owner to set PKKT per block", async () => {
+          pkktVault = await deployContract("PKKTVault", { signer: deployer as Signer, libraries: { Vault: vault.address } }, [pkktToken.address, "100", 13601000, trader.address]) as PKKTVault;
+
+          await expect(pkktVault.connect(alice as Signer).setPKKTPerBlock("200")).to.be.revertedWith("Only the owner or trader can set PKKT per block.");
+
+          await pkktVault.setPKKTPerBlock("200");
+          assert(await pkktVault.pkktPerBlock(), "200");
+
+          await pkktVault.connect(trader as Signer).setPKKTPerBlock("100");
+          assert(await pkktVault.pkktPerBlock, "100");
+        });
+
       });  
    
   });

--- a/test/PKKTVault.ts
+++ b/test/PKKTVault.ts
@@ -369,6 +369,13 @@ describe("PKKT Vault", async function () {
 
           await expect(pkktVault.initiateSettlement("100")).to.be.reverted;
 
+          await expect(pkktVault.connect(alice as Signer).grantRole(ethers.utils.formatBytes32String("TRADER_ROLE"), alice.address)).to.be.reverted;
+          assert.isNotTrue(
+            await pkktVault.hasRole(ethers.utils.formatBytes32String("TRADER_ROLE"), alice.address),
+            "Non-admin granted trader role"
+          );
+          await expect(pkktVault.initiateSettlement("100")).to.be.reverted;
+
           await pkktVault.revokeRole(ethers.utils.formatBytes32String("TRADER_ROLE"), trader.address);
           assert.isNotTrue(
             await pkktVault.hasRole(ethers.utils.formatBytes32String("TRADER_ROLE"), trader.address),

--- a/test/PKKTVault.ts
+++ b/test/PKKTVault.ts
@@ -147,7 +147,7 @@ describe("PKKT Vault", async function () {
           assert.equal(vaultInfo1.totalRequesting.toString(), "0");  
           assert.equal(vaultInfo2.totalRequesting.toString(), "0"); 
           assert.equal(vaultInfo3.totalRequesting.toString(), "0");  
-          await pkktVault.connect(trader as Signer).initiateSettlement("100");  
+          await pkktVault.connect(trader as Signer).initiateSettlement("100", trader.address);  
           /*const diff1 = await pkktVault.settlementResult[0];
           assert.equal(diff1.toString(), BigNumber.from(10).mul(USDTMultiplier).toString());
           const diff2 = await pkktVault.settlementResult[0];
@@ -229,7 +229,7 @@ describe("PKKT Vault", async function () {
           assert.equal(usdcVault.pendingAmount.toString(), BigNumber.from(2).mul(USDCMultiplier).toString());
           assert.equal(daiVault.pendingAmount.toString(), BigNumber.from(3).mul(DAIMultiplier).toString());
           
-          await pkktVault.connect(trader as Signer).initiateSettlement("100");  
+          await pkktVault.connect(trader as Signer).initiateSettlement("100", trader.address);  
 
           settelled = await pkktVault.isSettelled();
           assert.isFalse(settelled);
@@ -325,11 +325,11 @@ describe("PKKT Vault", async function () {
 
           await advanceBlockTo(13601199);
           //settlement at 13601200, the reward will be calculated 
-          await pkktVault.connect(trader as Signer).initiateSettlement("200");
+          await pkktVault.connect(trader as Signer).initiateSettlement("200", trader.address);
 
           await advanceBlockTo(13601299);
           //settlement at 13601300, the reward will be calculated 
-          await pkktVault.connect(trader as Signer).initiateSettlement("100");
+          await pkktVault.connect(trader as Signer).initiateSettlement("100", trader.address);
  
          
           var alicePkkt = (await pkktVault.pendingPKKT(0, alice.address)).
@@ -350,7 +350,7 @@ describe("PKKT Vault", async function () {
           await pkktVault.connect(alice as Signer).deposit(0, BigNumber.from(10).mul(USDTMultiplier)); 
           await advanceBlockTo(13601399);
           //settlement at 13601300, the reward will be calculated 
-          await pkktVault.connect(trader as Signer).initiateSettlement("100");
+          await pkktVault.connect(trader as Signer).initiateSettlement("100", trader.address);
           
           //todo: fix overflow issue
 
@@ -367,28 +367,28 @@ describe("PKKT Vault", async function () {
         it("should allow granting and revoking of trader role", async () => {
           pkktVault = await deployContract("PKKTVault", { signer:deployer as Signer, libraries:{Vault:vault.address} } , [pkktToken.address, "100", 13601000, trader.address]) as PKKTVault;
 
-          await expect(pkktVault.initiateSettlement("100")).to.be.reverted;
+          await expect(pkktVault.initiateSettlement("100", trader.address)).to.be.reverted;
 
           await expect(pkktVault.connect(alice as Signer).grantRole(ethers.utils.formatBytes32String("TRADER_ROLE"), alice.address)).to.be.reverted;
           assert.isNotTrue(
             await pkktVault.hasRole(ethers.utils.formatBytes32String("TRADER_ROLE"), alice.address),
             "Non-admin granted trader role"
           );
-          await expect(pkktVault.initiateSettlement("100")).to.be.reverted;
+          await expect(pkktVault.initiateSettlement("100", trader.address)).to.be.reverted;
 
           await pkktVault.revokeRole(ethers.utils.formatBytes32String("TRADER_ROLE"), trader.address);
           assert.isNotTrue(
             await pkktVault.hasRole(ethers.utils.formatBytes32String("TRADER_ROLE"), trader.address),
             "Trader role was not revoked."
           );
-          await expect(pkktVault.initiateSettlement("100")).to.be.reverted;
+          await expect(pkktVault.initiateSettlement("100", trader.address)).to.be.reverted;
 
           await pkktVault.grantRole(ethers.utils.formatBytes32String("TRADER_ROLE"), trader.address);
           assert.isTrue(
             await pkktVault.hasRole(ethers.utils.formatBytes32String("TRADER_ROLE"), trader.address),
             "Trader role was not granted"
           );
-          await pkktVault.connect(trader as Signer).initiateSettlement("100");
+          await pkktVault.connect(trader as Signer).initiateSettlement("100", trader.address);
         });
 
         it("should only allow the trader and owner to set PKKT per block", async () => {


### PR DESCRIPTION
I added an access role to PKKTVault that separates authorization between ownership/admin role and a trader role.  Now only the address granted the trader role can initiate and finish settlements, and only the owner/admin can add new vaults.